### PR TITLE
Now getting all S800 trig bits and added variable build iwndow option

### DIFF
--- a/include/TGRUTOptions.h
+++ b/include/TGRUTOptions.h
@@ -30,6 +30,8 @@ public:
 
   const std::vector<std::string>& OptionFiles() { return options_file; }
 
+  int BuildWindow() const { return fBuildWindow; }
+
   bool ExitAfterSorting()   const { return fExitAfterSorting; }
   bool ShowedHelp()         const { return fHelp; }
   bool ShowLogo()           const { return fShowLogo; }
@@ -87,6 +89,8 @@ private:
 
   bool fTimeSortInput;
   int fTimeSortDepth;
+
+  int fBuildWindow;
 
   bool fShouldExit;
 

--- a/libraries/TDetSystems/TS800/TS800.cxx
+++ b/libraries/TDetSystems/TS800/TS800.cxx
@@ -233,6 +233,9 @@ void TS800::Clear(Option_t* opt){
 }
 
 int TS800::BuildHits(){
+  if(raw_data.size() != 1){
+    std::cout << "Data buffers: " << raw_data.size() << std::endl;
+  }
   for(auto& event : raw_data) { // should only be one..
     SetTimestamp(event.GetTimestamp());
     // TGEBEvent* geb = (TGEBEvent*)&event;
@@ -335,8 +338,12 @@ int TS800::BuildHits(){
 }
 
 bool TS800::HandleTrigPacket(unsigned short *data,int size) {
-  if(size<1)
+  if(size<1){
+    static int i=0;
+    i++;
+    std::cout << "Encountered " << i << " events with empty trig packet" << std::endl;
     return false;
+  }
 
   trigger.SetRegistr(*data);
   for(int x=1;x<size;x++) {

--- a/libraries/TGRUTint/TGRUTOptions.cxx
+++ b/libraries/TGRUTint/TGRUTOptions.cxx
@@ -85,6 +85,9 @@ void TGRUTOptions::Load(int argc, char** argv) {
   parser.option("time-sort-depth",&fTimeSortDepth)
     .description("Number of events to hold when time sorting")
     .default_value(100000);
+  parser.option("build-window", &fBuildWindow)
+    .description("Build window, timestamp units")
+    .default_value(1000);
   parser.option("f format",&default_file_format)
     .description("File format of raw data.  Allowed options are \"EVT\" and \"GEB\"."
                  "If unspecified, will be guessed from the filename.");

--- a/libraries/TGRUTint/TGRUTint.cxx
+++ b/libraries/TGRUTint/TGRUTint.cxx
@@ -210,6 +210,7 @@ void TGRUTint::ApplyOptions() {
 
 
     TBuildingLoop *boop = TBuildingLoop::Get("2_build_loop",loop);
+    boop->SetBuildWindow(opt->BuildWindow());
     boop->Resume();
     TUnpackingLoop *uoop1 = TUnpackingLoop::Get("3_unpack1",boop);
     uoop1->Resume();

--- a/libraries/TLoops/TUnpackedEvent.cxx
+++ b/libraries/TLoops/TUnpackedEvent.cxx
@@ -64,9 +64,9 @@ void TUnpackedEvent::AddRawData(const TRawEvent& event, kDetectorSystems detecto
     GetDetector<TCaesar>(true)->AddRawData(event);
     break;
 
-    // Not implemented yet.
-  case kDetectorSystems::PHOSWALL:
-    break;
+  //   // Not implemented yet.
+  // case kDetectorSystems::PHOSWALL:
+  //   break;
 
   default:
     break;

--- a/libraries/TLoops/TUnpackingLoop.cxx
+++ b/libraries/TLoops/TUnpackingLoop.cxx
@@ -74,8 +74,11 @@ bool TUnpackingLoop::Iteration(){
   }
 
   fOutputEvent->Build();
-  output_queue.Push(fOutputEvent);
-  fOutputEvent = NULL;
+
+  if(fOutputEvent->GetDetectors().size() != 0){
+    output_queue.Push(fOutputEvent);
+    fOutputEvent = NULL;
+  }
   return true;
 }
 
@@ -131,7 +134,10 @@ void TUnpackingLoop::HandleGEBMode3(TGEBEvent& event, kDetectorSystems system){
 }
 
 void TUnpackingLoop::HandleNSCLPeriodicScalers(TNSCLEvent& event){
-  // TODO: Bring this in.
+  TUnpackedEvent* scaler_event = new TUnpackedEvent;
+  scaler_event->AddRawData(event, kDetectorSystems::S800SCALER);
+  scaler_event->Build();
+  output_queue.Push(scaler_event);
 }
 
 void TUnpackingLoop::HandleS800Scaler(TGEBEvent& event){

--- a/libraries/TLoops/TWriteLoop.cxx
+++ b/libraries/TLoops/TWriteLoop.cxx
@@ -4,6 +4,7 @@
 #include "TThread.h"
 
 #include "THistogramLoop.h"
+#include "TS800.h"
 
 #include <chrono>
 #include <thread>
@@ -146,7 +147,7 @@ void TWriteLoop::WriteEvent(TUnpackedEvent* event) {
   }
 
   // Load current events
-  for(auto det : event->GetDetectors()) {
+  for(auto det : event->GetDetectors()) {    
     TClass* cls = det->IsA();
     *det_map.at(cls) = det;
   }


### PR DESCRIPTION
Note that the S800 trigbit registr will still have 65535 data for all scaler events, but these can be safely ignored until GRUTinizer is updated to separate the event tree and scaler tree
