### PR TITLE
Fixed -1 timestamps causing errors in readout, now SpecTcl and CAESAR…

### DIFF
--- a/libraries/TDetSystems/TCaesar/TCaesar.cxx
+++ b/libraries/TDetSystems/TCaesar/TCaesar.cxx
@@ -7,7 +7,7 @@
 #define FERA_TIMESTAMP_ID   0x2303
 #define FERA_ERROR_ID       0x23ff
 
-#define DEBUG_BRANDON 1
+#define DEBUG_BRANDON 0
 
 TCaesar::TCaesar() {
   Clear();

--- a/libraries/TLoops/TBuildingLoop.cxx
+++ b/libraries/TLoops/TBuildingLoop.cxx
@@ -69,7 +69,13 @@ bool TBuildingLoop::Iteration(){
 
 bool TBuildingLoop::CheckBuildWindow(TRawEvent *event) {
   long timestamp = event->GetTimestamp();
-  if(timestamp > event_start + build_window) {
+
+  if(timestamp == -1){
+    return false;
+  }
+  
+  if(timestamp > event_start + build_window ||
+     timestamp < event_start - build_window) {
     //next_event->Build();
     output_queue.Push(next_event);
     next_event.clear(); // = new TUnpackedEvent;

--- a/libraries/TLoops/TUnpackingLoop.cxx
+++ b/libraries/TLoops/TUnpackingLoop.cxx
@@ -111,7 +111,7 @@ void TUnpackingLoop::HandleNSCLData(TNSCLEvent& event) {
 }
 
 
-void TUnpackingLoop::HandleBuiltNSCLData(TNSCLEvent& event){
+void TUnpackingLoop::HandleBuiltNSCLData(TNSCLEvent& event){  
   TNSCLBuiltRingItem built(event);
   for(unsigned int i=0; i<built.NumFragments(); i++){
     TNSCLFragment& fragment = built.GetFragment(i);

--- a/libraries/TRawFormat/TRawEvent.cxx
+++ b/libraries/TRawFormat/TRawEvent.cxx
@@ -190,6 +190,7 @@ void TRawEvent::Print(Option_t *opt) const {
   TString options(opt);
   if(!options.Contains("bodyonly"))
     std::cout << fEventHeader;
+  std::cout << "Timestamp: " << GetTimestamp() << std::endl;
   fBody.Print(options.Data());
   // printf("\t");
   // for(int x=0; x<GetBodySize(); x+=2) {


### PR DESCRIPTION
… seem to exactly match sans 1 count
