### PR TITLE
Fixed bug in TRawEvent &TRawEvent::operator=(const TRawEvent &rhs)

### DIFF
--- a/libraries/TRawFormat/TRawEvent.cxx
+++ b/libraries/TRawFormat/TRawEvent.cxx
@@ -45,6 +45,7 @@ TRawEvent &TRawEvent::operator=(const TRawEvent &rhs) {
   fEventHeader = rhs.fEventHeader;
   fBody        = rhs.fBody;
   fFileType    = rhs.fFileType;
+  fTimestamp   = rhs.fTimestamp;
   return *this;
 }
 


### PR DESCRIPTION
Fixed bug in TRawEvent &TRawEvent::operator=(const TRawEvent &rhs) in which not all members of TRawEvent were being copied (namely fTimestamp).
