### PR TITLE
TMultiRawFile - Stalled source feature

### DIFF
--- a/libraries/TLoops/TDataLoop.cxx
+++ b/libraries/TLoops/TDataLoop.cxx
@@ -62,11 +62,6 @@ bool TDataLoop::Iteration() {
     output_queue.Push(evt);
     return true;
   } else {
-    static TRawEventSource* source_ptr = NULL;
-    if(source_ptr != source){
-      std::cout << "Finished reading source" << std::endl;
-      source_ptr = source;
-    }
     // Nothing returned this time, but I might get something next time.
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     return true;

--- a/libraries/TRawFormat/TRawEventSource.cxx
+++ b/libraries/TRawFormat/TRawEventSource.cxx
@@ -15,7 +15,7 @@ int TRawEventSource::Read(TRawEvent& event){
     int result = GetEvent(event);
     if(result > 0){
       UpdateByteThroughput(event.GetTotalSize());
-    } else if (result < 0) {
+    } else if (result < 0 && TGRUTOptions::Get()->ExitAfterSorting()) {
       fIsFinished = true;
     }
     return result;


### PR DESCRIPTION
## Motivation: 

Prior to this, TMultiRawFile did not handle the case in which multiple data sources are read and time correlated online. This pull request adds that functionality.
## Details: 

If ExitAfterSort (-q) is not specified, a TMultiRawFile source (-m) will not close a subordinate source when it reaches the last of its events. Instead it will enter a stalled source state and will wait until a new event arrives for that source. This ensures correct time ordering during online runs. It should be noted that this will prevent the processing of other files in the TMultiRawFile until more data arrives for the stalled source. If this behavior is not desired, then either the -m flag should not be specified when processing multiple data files, or -mq should be used, in which case the TMultiRawFile will never enter a stalled state as data will be processed in offline mode.
