### PR TITLE
Large filesize support for 32bit systems

### DIFF
--- a/libraries/TGRUTUtil/TGRUTUtilities.cxx
+++ b/libraries/TGRUTUtil/TGRUTUtilities.cxx
@@ -13,8 +13,8 @@
 
 bool file_exists(const char *filename){
   //std::ifstream(filename);
-  struct stat buffer;
-  return (stat(filename,&buffer)==0);
+  struct stat64 buffer;
+  return (stat64(filename,&buffer)==0);
 }
 
 bool all_files_exist(const std::vector<std::string>& filenames) {

--- a/libraries/TRawFormat/TGZipByteSource.cxx
+++ b/libraries/TRawFormat/TGZipByteSource.cxx
@@ -4,7 +4,7 @@
 
 TGZipByteSource::TGZipByteSource(const std::string& filename)
   : fFilename(filename) {
-  fFile = fopen(filename.c_str(),"rb");
+  fFile = fopen64(filename.c_str(),"rb");
   fGzFile = new gzFile;
   *fGzFile = gzdopen(fileno(fFile),"rb");
 }


### PR DESCRIPTION
Files over ~2 GB could not be opened on my 32-bit system.  These two modest changes appear to fix the issue.